### PR TITLE
RST-376 Publish visualization messages in a separate thread

### DIFF
--- a/src/slam_karto.cpp
+++ b/src/slam_karto.cpp
@@ -516,7 +516,7 @@ SlamKarto::publishGraphVisualization()
     }
 
     visualization_msgs::Marker nodes;
-    nodes.header.frame_id = "map";
+    nodes.header.frame_id = map_frame_;
     nodes.header.stamp = ros::Time::now();
     nodes.ns = "karto";
     nodes.id = 0;
@@ -535,7 +535,7 @@ SlamKarto::publishGraphVisualization()
     nodes.lifetime = ros::Duration(0);
 
     visualization_msgs::Marker edges;
-    edges.header.frame_id = "map";
+    edges.header.frame_id = map_frame_;
     edges.header.stamp = ros::Time::now();
     edges.ns = "karto";
     edges.id = 1;


### PR DESCRIPTION
This PR: 
* publishes the graph visualization messages from the same thread as the map generation. This reduces bandwidth, as the markers are published infrequently, and minimizes the impact of publishing from the main algorithm thread. 
* modifies the visualization messages to use the list-type markers instead of individual markers to reduce rviz CPU load (see http://wiki.ros.org/rviz/DisplayTypes/Marker#Rendering_Complexity_Notes).

https://locusrobotics.atlassian.net/browse/RST-377