### PR TITLE
RST-375 run the karto mapping process is a separate thread

### DIFF
--- a/src/slam_karto.cpp
+++ b/src/slam_karto.cpp
@@ -529,22 +529,18 @@ SlamKarto::optimizationLoop()
     {
       resumeNavigation();
     }
-    // Get the next laser scan off the queue and unlock
-    // so ROS can continue filling the buffer.
+    // Get the next laser scan off the queue and unlock so ROS can continue filling the buffer.
     karto::LocalizedRangeScan* range_scan = scan_queue_.front();
     scan_queue_.pop_front();
     scan_queue_lock.unlock();
-    // But now we need to use the karto mapper.
-    // Acquire a lock for it before modifying
-    // the graph.
+    // But now we need to use the karto mapper. Acquire a lock for it before modifying the graph.
     bool processed = false;
     {
       boost::mutex::scoped_lock lock(mapper_mutex_);
       // Finally, process the scan with karto
       processed = mapper_->Process(range_scan);
     }
-    // If this scan was successfully processed, then update the
-    // tf map->odom transform
+    // If this scan was successfully processed, then update the tf map->odom transform
     if (processed)
     {
       // Update the map->odom transform using this scan's optimized pose

--- a/src/slam_karto.cpp
+++ b/src/slam_karto.cpp
@@ -151,6 +151,11 @@ class SlamKarto
      */
     void optimizationLoop();
 
+    /**
+     * @brief Display the queue fill precentage above the robot
+     */
+    void publishQueueVisualization();
+
     // ROS handles
     ros::NodeHandle node_;
     tf::TransformListener tf_;
@@ -805,6 +810,39 @@ SlamKarto::publishGraphVisualization()
 }
 
 void
+SlamKarto::publishQueueVisualization()
+{
+  // Publish queue status
+  if (scan_queue_.capacity() > 1 && marker_publisher_.getNumSubscribers() > 0)
+  {
+    visualization_msgs::Marker queue_size;
+    queue_size.header.frame_id = base_frame_;
+    queue_size.header.stamp = ros::Time::now();
+    queue_size.ns = "karto_scan_queue";
+    queue_size.id = 0;
+    queue_size.action = visualization_msgs::Marker::ADD;
+    queue_size.type = visualization_msgs::Marker::TEXT_VIEW_FACING;
+    queue_size.pose.position.x = 0.0;
+    queue_size.pose.position.y = 0.40;
+    queue_size.pose.position.z = 0.0;
+    queue_size.scale.x = 0.25;
+    queue_size.scale.y = 0.25;
+    queue_size.scale.z = 0.25;
+    queue_size.color.r = 0.0;
+    queue_size.color.g = 0.0;
+    queue_size.color.b = 0.0;
+    queue_size.color.a = 1.0;
+    queue_size.text = "queue: " + boost::lexical_cast<std::string>(static_cast<int>(queueFillPercentage()*100)) + "%";
+    queue_size.lifetime = ros::Duration(0.0);
+    queue_size.frame_locked = true;
+
+    visualization_msgs::MarkerArray marray;
+    marray.markers.push_back(queue_size);
+    marker_publisher_.publish(marray);
+  }
+}
+
+void
 SlamKarto::laserCallback(const sensor_msgs::LaserScan::ConstPtr& scan)
 {
   laser_count_++;
@@ -882,6 +920,7 @@ SlamKarto::mapLoop(double map_update_interval)
   {
     updateMap();
     publishGraphVisualization();
+    publishQueueVisualization();
     r.sleep();
   }
 }

--- a/src/slam_karto.cpp
+++ b/src/slam_karto.cpp
@@ -592,7 +592,7 @@ SlamKarto::publishLoop(double transform_publish_period)
   if(transform_publish_period == 0)
     return;
 
-  ros::Rate r(1.0 / transform_publish_period);
+  ros::WallRate r(1.0 / transform_publish_period);
   while(ros::ok())
   {
     publishTransform();
@@ -877,7 +877,7 @@ SlamKarto::mapLoop(double map_update_interval)
     return;
 
   // Configure a rate loop for regenerating the map
-  ros::Rate r(1.0 / map_update_interval);
+  ros::WallRate r(1.0 / map_update_interval);
   while (ros::ok())
   {
     updateMap();


### PR DESCRIPTION
Previously the karto mapping computation and the ROS subscriber callbacks ran in the same thread. If the karto processing takes too long, then laserscan messages are dropped. If enough scans are dropped, some environment structure may be missing from the output map.

The slam_karto node has been refactored with a producer-consumer architecture. The main ROS subscriber thread inserts laserscans into a queue. In a separate thread, karto pulls scans out of the queue and processes them. Additionally, the robot can be paused if the laserscan queue gets too full, and resumed when the queue becomes empty again.

By default, the queue size is set to 1 and the pause/resume feature is disabled. In this configuration karto behaves the same as before - laserscans will be dropped if karto's processing lags behind. However, if you want to build a map offline, you can increase the queue size and enable the `pause_on_full_queue` feature. This will allow karto to process data at its own pace, pausing the incoming data if it gets too far behind. Also, the queue percentage has been added as an rviz visualization so it is easy to monitor.

https://locusrobotics.atlassian.net/browse/RST-375