### PR TITLE
RST-419 always publish in map frame

### DIFF
--- a/include/slam_karto/map_alignment_tool.h
+++ b/include/slam_karto/map_alignment_tool.h
@@ -46,7 +46,7 @@ protected:
   tf2_ros::StaticTransformBroadcaster static_broadcaster_;  //!< Broadcasts the static aligned->map transform
   interactive_markers::InteractiveMarkerServer interactive_marker_server_;  //!< Server for interactive markers
   interactive_markers::MenuHandler menu_handler_;  //!< Interactive marker menu handler
-  std::string aligned_frame_;  //!< The name of the 'aligned' frame
+  std::string local_map_frame_;  //!< The name of the 'local map' frame
   std::string map_frame_;  //!< The name of the 'map' frame
 
   /**

--- a/src/map_alignment_tool.cpp
+++ b/src/map_alignment_tool.cpp
@@ -22,11 +22,11 @@ static const std::string connector_name = "connector";
 MapAlignmentTool::MapAlignmentTool(const ros::NodeHandle& node_handle, const ros::NodeHandle& private_node_handle) :
   node_handle_(node_handle),
   interactive_marker_server_("map_alignment_tool"),
-  aligned_frame_("map_aligned"),
+  local_map_frame_("map_local"),
   map_frame_("map")
 {
   // Read the frame names from the parameter server
-  private_node_handle.getParam("aligned_frame", aligned_frame_);
+  private_node_handle.getParam("local_map_frame", local_map_frame_);
   private_node_handle.getParam("map_frame", map_frame_);
   // Create the map alignment visualization markers
   visualization_msgs::InteractiveMarker endpoint1 = createEndpoint(endpoint1_name);
@@ -56,7 +56,7 @@ visualization_msgs::InteractiveMarker MapAlignmentTool::createEndpoint(const std
 {
   // Create alignment markers
   visualization_msgs::InteractiveMarker endpoint;
-  endpoint.header.frame_id = map_frame_;
+  endpoint.header.frame_id = local_map_frame_;
   endpoint.name = name;
   endpoint.pose.position.x = 0;
   endpoint.pose.position.y = 0;
@@ -87,7 +87,7 @@ visualization_msgs::InteractiveMarker MapAlignmentTool::createEndpoint(const std
 visualization_msgs::InteractiveMarker MapAlignmentTool::createConnector(const std::string& name) const
 {
   visualization_msgs::InteractiveMarker connector;
-  connector.header.frame_id = map_frame_;
+  connector.header.frame_id = local_map_frame_;
   connector.name = name;
   connector.pose.position.x = 0;
   connector.pose.position.y = 0;
@@ -145,16 +145,16 @@ void MapAlignmentTool::alignMapCallback(const visualization_msgs::InteractiveMar
       endpoint2.pose.position.x - endpoint1.pose.position.x);
 
     // Publish aligned->map frame transformation
-    geometry_msgs::TransformStamped aligned_to_map_transform;
-    aligned_to_map_transform.header.stamp = ros::Time(0, 0);
-    aligned_to_map_transform.header.frame_id = aligned_frame_;
-    aligned_to_map_transform.child_frame_id = map_frame_;
-    aligned_to_map_transform.transform.translation.x = 0;
-    aligned_to_map_transform.transform.translation.y = 0;
-    aligned_to_map_transform.transform.translation.z = 0;
+    geometry_msgs::TransformStamped map_to_local_transform;
+    map_to_local_transform.header.stamp = ros::Time(0, 0);
+    map_to_local_transform.header.frame_id = map_frame_;
+    map_to_local_transform.child_frame_id = local_map_frame_;
+    map_to_local_transform.transform.translation.x = 0;
+    map_to_local_transform.transform.translation.y = 0;
+    map_to_local_transform.transform.translation.z = 0;
     // send the opposite rotation so the map frame will end up in the requested orientation
-    aligned_to_map_transform.transform.rotation = tf::createQuaternionMsgFromYaw(-yaw);
-    static_broadcaster_.sendTransform(aligned_to_map_transform);
+    map_to_local_transform.transform.rotation = tf::createQuaternionMsgFromYaw(-yaw);
+    static_broadcaster_.sendTransform(map_to_local_transform);
   }
 }
 

--- a/src/slam_karto.cpp
+++ b/src/slam_karto.cpp
@@ -262,7 +262,7 @@ SlamKarto::SlamKarto() :
   private_nh_.param("pause_on_loop_closure", pause_on_loop_closure_, false);
   private_nh_.param("pause_on_full_queue", pause_on_full_queue_, false);
   private_nh_.param("pause_navigation_percentage", pause_navigation_percentage_, 0.90);
-  private_nh_.param("resume_navigation_percentage_", resume_navigation_percentage_, 0.10);
+  private_nh_.param("resume_navigation_percentage", resume_navigation_percentage_, 0.10);
   pause_navigation_percentage_ = boost::algorithm::clamp(pause_navigation_percentage_, 0.0, 1.0);
   resume_navigation_percentage_ = boost::algorithm::clamp(resume_navigation_percentage_,
     0.0, pause_navigation_percentage_);

--- a/src/slam_karto.cpp
+++ b/src/slam_karto.cpp
@@ -170,6 +170,7 @@ class SlamKarto
     ros::ServiceServer ss_;
     ros::Publisher pause_publisher_;  //!< Topic that publishes requests to pause/unpause navigation
     ros::ServiceClient pause_service_client_;  //!< Service client that requests to pause/unpause navigation
+    ros::WallTimer queue_visualization_timer_;  //!< Timer used to publish the scan queue length visualization
 
     // The map that will be published / send to service callers
     nav_msgs::GetMap::Response map_;
@@ -272,6 +273,8 @@ SlamKarto::SlamKarto() :
     if (scan_queue_length > 0)
     {
       scan_queue_.set_capacity(scan_queue_length);
+      queue_visualization_timer_ = private_nh_.createWallTimer(ros::WallDuration(1.0),
+        boost::bind(&SlamKarto::publishQueueVisualization, this));
     }
     else
     {
@@ -907,7 +910,6 @@ SlamKarto::mapLoop(double map_update_interval)
   {
     updateMap();
     publishGraphVisualization();
-    publishQueueVisualization();
     r.sleep();
   }
 }

--- a/src/slam_karto.cpp
+++ b/src/slam_karto.cpp
@@ -468,7 +468,7 @@ SlamKarto::~SlamKarto()
   // Notify the queue condition variable so it will wake up from its sleep
   scan_queue_data_available_.notify_all();
   // Shutdown all of the threads
-  if(transform_thread_)
+  if (transform_thread_)
   {
     transform_thread_->join();
     delete transform_thread_;
@@ -493,12 +493,6 @@ SlamKarto::~SlamKarto()
     delete mapper_;
   if (dataset_)
     delete dataset_;
-  for (std::map<std::string, karto::LaserRangeFinder*>::iterator iter = lasers_.begin();
-       iter != lasers_.end();
-       ++iter)
-  {
-    delete iter->second;
-  }
   lasers_.clear();
   if (loop_closure_pauser_)
     delete loop_closure_pauser_;


### PR DESCRIPTION
Modified slam_karto to publish maps in the map_frame. Use of the previous 'aligned' frame works fine in bagfile playback, but it does not play well with move_base. Modified karto to perform all optimization in an intermediate, local map frame. A static transform from map to local_map is automatically published if one does not exist. This allows the map frame to be rotated using the map alignment tool, or through a manually published transform.

Some additional clean up was performed as the result of live robot testing:
* added a scope block to control a mutex lock scope
* fixed an error in a parameter name
* modified the visualization topic names to be meaningful
* moved the queue size visualization into its own loop for better responsiveness

https://locusrobotics.atlassian.net/browse/RST-419