### PR TITLE
[0.0.14] RST-452 Export map->local transform as a yaml file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(catkin REQUIRED
     sensor_msgs
     sparse_bundle_adjustment
     std_msgs
+    std_srvs
     tf
     tf2
     tf2_ros

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(catkin REQUIRED
     roscpp
     sensor_msgs
     sparse_bundle_adjustment
+    std_msgs
     tf
     tf2
     tf2_ros

--- a/include/slam_karto/map_alignment_tool.h
+++ b/include/slam_karto/map_alignment_tool.h
@@ -10,7 +10,6 @@
 #include <interactive_markers/interactive_marker_server.h>
 #include <interactive_markers/menu_handler.h>
 #include <ros/ros.h>
-#include <tf2_ros/static_transform_broadcaster.h>
 
 #include <string>
 
@@ -43,11 +42,11 @@ public:
 
 protected:
   ros::NodeHandle node_handle_;  //!< Node handle for this node
-  tf2_ros::StaticTransformBroadcaster static_broadcaster_;  //!< Broadcasts the static aligned->map transform
+  ros::Publisher map_rotation_publisher_;  //!< Publish the desired map rotation angle
   interactive_markers::InteractiveMarkerServer interactive_marker_server_;  //!< Server for interactive markers
   interactive_markers::MenuHandler menu_handler_;  //!< Interactive marker menu handler
-  std::string local_map_frame_;  //!< The name of the 'local map' frame
   std::string map_frame_;  //!< The name of the 'map' frame
+  std::string local_map_frame_;  //!< The name of the 'local map' frame
 
   /**
    * @brief Create an interactive marker message for one of the two alignment tool endpoints

--- a/package.xml
+++ b/package.xml
@@ -20,8 +20,9 @@
   <build_depend>open_karto</build_depend>
   <build_depend>rosconsole</build_depend>
   <build_depend>roscpp</build_depend>
-  <build_depend>sparse_bundle_adjustment</build_depend>
   <build_depend>sensor_msgs</build_depend>
+  <build_depend>sparse_bundle_adjustment</build_depend>
+  <build_depend>std_msgs</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>tf2</build_depend>
   <build_depend>tf2_ros</build_depend>
@@ -35,8 +36,9 @@
   <run_depend>open_karto</run_depend>
   <run_depend>rosconsole</run_depend>
   <run_depend>roscpp</run_depend>
-  <run_depend>sparse_bundle_adjustment</run_depend>
   <run_depend>sensor_msgs</run_depend>
+  <run_depend>sparse_bundle_adjustment</run_depend>
+  <run_depend>std_msgs</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>tf2</run_depend>
   <run_depend>tf2_ros</run_depend>

--- a/package.xml
+++ b/package.xml
@@ -23,6 +23,7 @@
   <build_depend>sensor_msgs</build_depend>
   <build_depend>sparse_bundle_adjustment</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>std_srvs</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>tf2</build_depend>
   <build_depend>tf2_ros</build_depend>
@@ -39,6 +40,7 @@
   <run_depend>sensor_msgs</run_depend>
   <run_depend>sparse_bundle_adjustment</run_depend>
   <run_depend>std_msgs</run_depend>
+  <run_depend>std_srvs</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>tf2</run_depend>
   <run_depend>tf2_ros</run_depend>


### PR DESCRIPTION
This is part of a refactor to export the map->local_map transform for downstream LP processing. There is  another PR in locus_bots (locusrobotics/locus_bots#159) that updates the launch files and actually writes the transform file.

This PR:
* Modifies the map alignment tool interface to send slam_karto the desired rotation angle on a special topic (rather than publishing a static tf transform)
* Modifies slam_karto to subscribe to the map_rotation topic and rotate the map accordingly
* Modifies slam_karto to always publish "zero-ed" maps i.e. origin is always (0,0)
* Modifies slam_karto to always publish an updated map->local_map transform with each map

This removes the need to translate the map and LP points in a separate step, the rotation and translation are incorporated into a single transform step. This is done at the map construction step because the coordinates of the lower-left pixel are not known until the map image is constructed. This also avoids a tf race condition that was occurring between the map alignment tool and slam_karto map building thread.

https://locusrobotics.atlassian.net/browse/RST-452