### PR TITLE
[0.0.15] [RST-626] slam_karto angle update threshold

### DIFF
--- a/src/slam_karto.cpp
+++ b/src/slam_karto.cpp
@@ -1078,7 +1078,7 @@ bool SlamKarto::hasMovedEnough(const karto::LocalizedRangeScan* scan)
 
   // Check rotation
   double delta_heading = karto::math::NormalizeAngle(current_laser_pose.GetHeading() - last_scan_pose_.GetHeading());
-  if (std::fabs(delta_heading) >= mapper_->getParamMinimumTravelHeading())
+  if (std::fabs(delta_heading) >= karto::math::DegreesToRadians(mapper_->getParamMinimumTravelHeading()))
   {
     return true;
   }


### PR DESCRIPTION
Fixed the angle update threshold in slam_karto. The parameter setter uses radians, but the getter returns degrees. Thanks karto.

https://locusrobotics.atlassian.net/browse/RST-626