### PR TITLE
Rst 7062 remove map local frame

### DIFF
--- a/src/slam_karto.cpp
+++ b/src/slam_karto.cpp
@@ -210,7 +210,7 @@ class SlamKarto
     std::string odom_frame_;
     std::string map_frame_;  //!< The map will be constructed and published in the map frame
     std::string base_frame_;
-    slam_karto::SetMapTransform::Request map_requested_transform_;  //!< The last received map->local transform request
+    slam_karto::SetMapTransform::Request map_requested_transform_;  //!< The last received map transform request
     bool map_requested_transform_dirty_;  //!< Flag indicating a new request was received
     int throttle_scans_;
     double resolution_;

--- a/src/spa_solver.cpp
+++ b/src/spa_solver.cpp
@@ -60,7 +60,7 @@ void SpaSolver::Compute()
 
 void SpaSolver::AddNode(karto::Vertex<karto::LocalizedRangeScan>* pVertex)
 {
-  karto::Pose2 pose = pVertex->GetObject()->GetCorrectedPose();
+  karto::Pose2 pose = pVertex->GetObject()->GetSensorPose();
   Eigen::Vector3d vector(pose.GetX(), pose.GetY(), pose.GetHeading());
   m_Spa.addNode(vector, pVertex->GetObject()->GetUniqueId());
 }


### PR DESCRIPTION
### Tf tree

Before Karto was working with `map` <- _`tf_static`_ -> `map_local` <- _`tf`_ -> `odom` <-_`tf`_->`base_link`

- Removed map_local frame so tf looks like this:
`map` <- _`tf_static`_ -> `odom` <-_`tf`_->`base_link`

### Graph Bug:

When running slam_karto, it is possible to see that initially, the graph is using the robot pose, so the _"rings"_ are not visible
However, as we can observe in [the video](https://locusrobotics-my.sharepoint.com/:v:/p/cribeiromendes/Ec0FKLDeJUNAu1eD0VI4ojgBneY-M6Rc40FtlVnNFkWtOw?e=rzvrRZ) (from second 19 to second 21), as soon as the optimizer runs, the graph changes and we now see these rings appear.

This can only mean that the optimizer is the one to blame. It is possible to verify that it is receiving mixed information, i.e., the constraints do not match with the registered nodes.

`open_karto` calls/uses the solver/optimizer in exactly 3 places:

1. Add Vertices: https://github.com/ros-perception/open_karto/blob/3ef9f6baae5e277263068705ca0e1e406424da19/src/Mapper.cpp#L871-L874
2. Add Constraints: https://github.com/ros-perception/open_karto/blob/3ef9f6baae5e277263068705ca0e1e406424da19/src/Mapper.cpp#L1068-L1072
3. To Correct poses:
https://github.com/ros-perception/open_karto/blob/3ef9f6baae5e277263068705ca0e1e406424da19/src/Mapper.cpp#L1318-L1333

In `1.` there is no information about how this pose should be registered, sensor pose? robot pose?
In `2.` we can see that the link/constraint is inserted in relation to the sensor pose, not the robot pose
In `3.` we can see that the optimization output is used to update the sensor pose in each LocalizedRangeScan.

So, based on `2.` and `3.`, we should conclude that in `1.`, the scan solver should be using the sensor pose and not the robot pose, and that is why [this](https://github.com/locusrobotics/slam_karto/pull/3/commits/e2422180f560fc1ae7d09e1347bfbf123f1638f0) was changed. We will still see the graph with the small rings as we are using the optimizer to create it.
