### PR TITLE
[RST-7375] Publish the SLAM graph as a structured message for Magellan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(slam_karto)
 find_package(catkin REQUIRED
   COMPONENTS
     geometry_msgs
+    locus_msgs
     message_filters
     message_generation
     nav_msgs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ include_directories(
 add_definitions(${EIGEN_DEFINITIONS})
 
 add_executable(slam_karto
+  src/graph_update.cpp
   src/loop_closure_callback.cpp
   src/slam_karto.cpp
   src/spa_solver.cpp
@@ -66,3 +67,20 @@ target_link_libraries(slam_karto
 install(TARGETS slam_karto
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
+
+if(CATKIN_ENABLE_TESTING)
+  find_package(roslint REQUIRED)
+  find_package(rostest REQUIRED)
+
+  # Test for the GraphUpdate message utilities
+  catkin_add_gtest(test_graph_update
+    src/graph_update.cpp
+    test/test_graph_update.cpp
+  )
+  add_dependencies(test_graph_update
+    ${catkin_EXPORTED_TARGETS}
+  )
+  target_link_libraries(test_graph_update
+    ${catkin_LIBRARIES}
+  )
+endif()

--- a/include/slam_karto/graph_update.h
+++ b/include/slam_karto/graph_update.h
@@ -23,7 +23,7 @@ namespace slam_karto
  * @param[in,out] graph - Graph to update
  * @param[in] changes - A set of graph changes
  */
-void applyGraphChanges(locus_msgs::GraphStamped& current, const locus_msgs::GraphUpdate& changes);
+void applyGraphUpdates(locus_msgs::GraphStamped& current, const locus_msgs::GraphUpdate& updates);
 
 /**
  * @brief Compute the changes between two graphs

--- a/include/slam_karto/graph_update.h
+++ b/include/slam_karto/graph_update.h
@@ -1,0 +1,35 @@
+/***************************************************************************
+ * Copyright (C) 2023 Locus Robotics. All rights reserved.
+ * Unauthorized copying of this file, via any medium, is strictly prohibited
+ * Proprietary and confidential
+ ***************************************************************************/
+
+#ifndef SLAM_KARTO_GRAPH_UPDATE_H
+#define SLAM_KARTO_GRAPH_UPDATE_H
+
+#include <locus_msgs/Edge.h>
+#include <locus_msgs/GraphStamped.h>
+#include <locus_msgs/GraphUpdate.h>
+#include <locus_msgs/Node.h>
+
+namespace slam_karto
+{
+/**
+ * @brief Compute the changes between two graphs
+ *
+ * The input graphs are expected to be sorted by node id for both the nodes list and edges list. Calling
+ * computeGraphChanges() on unsorted graphs results in undefined behavior.
+ *
+ * @param[in] current - The new graph
+ * @param[in] previous - The original reference graph
+ * @param[in] change_threshold - Tolerence for node position changes
+ * @return The set of additions and modification present in \p current that do not exist in \p previous
+ */
+locus_msgs::GraphUpdate computeGraphChanges(
+  const locus_msgs::GraphStamped& current,
+  const locus_msgs::GraphStamped& previous,
+  const double change_threshold = 0.05);
+
+}  // namespace slam_karto
+
+#endif  // SLAM_KARTO_GRAPH_UPDATE_H

--- a/include/slam_karto/graph_update.h
+++ b/include/slam_karto/graph_update.h
@@ -15,6 +15,17 @@
 namespace slam_karto
 {
 /**
+ * @brief Update the input graph with the supplied set of graph updates
+ *
+ * The input graph and changes are expected to be sorted by node id for both the nodes list and edges list. Calling
+ * applyGraphChanges() on unsorted graphs results in undefined behavior.
+ *
+ * @param[in,out] graph - Graph to update
+ * @param[in] changes - A set of graph changes
+ */
+void applyGraphChanges(locus_msgs::GraphStamped& current, const locus_msgs::GraphUpdate& changes);
+
+/**
  * @brief Compute the changes between two graphs
  *
  * The input graphs are expected to be sorted by node id for both the nodes list and edges list. Calling
@@ -30,6 +41,23 @@ locus_msgs::GraphUpdate computeGraphChanges(
   const locus_msgs::GraphStamped& previous,
   const double change_threshold = 0.05);
 
+/**
+ * @brief Comparison function for edges used as sorting criteria
+ *
+ * @param[in] lhs - Edge on the left hand side of the comparison function
+ * @param[in] rhs - Edge on the right hand side of the comparison function
+ * @return True if lhs is less than rhs
+ */
+bool edgeComparison(const locus_msgs::Edge& lhs, const locus_msgs::Edge& rhs);
+
+/**
+ * @brief Comparison function for nodes used as sorting criteria
+ *
+ * @param[in] lhs - Node on the left hand side of the comparison function
+ * @param[in] rhs - Node on the right hand side of the comparison function
+ * @return True if lhs is less than rhs
+ */
+bool nodeComparison(const locus_msgs::Node& lhs, const locus_msgs::Node& rhs);
 }  // namespace slam_karto
 
 #endif  // SLAM_KARTO_GRAPH_UPDATE_H

--- a/package.xml
+++ b/package.xml
@@ -47,4 +47,6 @@
   <run_depend>tf2_ros</run_depend>
   <run_depend>visualization_msgs</run_depend>
 
+  <test_depend>roslint</test_depend>
+  <test_depend>rostest</test_depend>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,7 @@
 
   <build_depend>eigen</build_depend>
   <build_depend>geometry_msgs</build_depend>
+  <build_depend>locus_msgs</build_depend>
   <build_depend>message_filters</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>nav_msgs</build_depend>
@@ -30,6 +31,7 @@
 
   <run_depend>eigen</run_depend>
   <run_depend>geometry_msgs</run_depend>
+  <run_depend>locus_msgs</run_depend>
   <run_depend>message_filters</run_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>nav_msgs</run_depend>

--- a/src/graph_update.cpp
+++ b/src/graph_update.cpp
@@ -1,0 +1,62 @@
+/***************************************************************************
+ * Copyright (C) 2023 Locus Robotics. All rights reserved.
+ * Unauthorized copying of this file, via any medium, is strictly prohibited
+ * Proprietary and confidential
+ ***************************************************************************/
+
+#include <slam_karto/graph_update.h>
+
+#include <locus_cpp/math.h>
+#include <locus_msgs/Edge.h>
+#include <locus_msgs/GraphStamped.h>
+#include <locus_msgs/GraphUpdate.h>
+#include <locus_msgs/Node.h>
+
+#include <ros/console.h>
+
+#include <algorithm>
+#include <iterator>
+
+namespace slam_karto
+{
+locus_msgs::GraphUpdate computeGraphChanges(
+  const locus_msgs::GraphStamped& current,
+  const locus_msgs::GraphStamped& previous,
+  const double change_threshold)
+{
+  auto updates = locus_msgs::GraphUpdate();
+  updates.header = current.header;
+  // Find nodes in the current graph that do not exist in the previous graph, or have substantially changed position
+  // The comparison function first checks that the lhs ID is smaller than the rhs ID. If the IDs are the same, we then
+  // check the different in positions. Instead of a standard equality, we allow +/- tolerance around the positions to
+  // mean "equal" as well.
+  std::set_difference(
+    current.graph.nodes.begin(),
+    current.graph.nodes.end(),
+    previous.graph.nodes.begin(),
+    previous.graph.nodes.end(),
+    std::back_inserter(updates.node_changes),
+    [tolerance = change_threshold](const locus_msgs::Node& lhs, const locus_msgs::Node& rhs)
+    {
+      return (lhs.id < rhs.id) ||
+             (lhs.id == rhs.id && ((lhs.position.x < rhs.position.x - tolerance) ||
+             (lhs.position.x < rhs.position.x + tolerance && lhs.position.y < rhs.position.y - tolerance)));
+    });
+
+  // Find the edges in the current graph that do not exist in the previous graph
+  std::set_difference(
+    current.graph.edges.begin(),
+    current.graph.edges.end(),
+    previous.graph.edges.begin(),
+    previous.graph.edges.end(),
+    std::back_inserter(updates.edge_changes),
+    [](const locus_msgs::Edge& lhs, const locus_msgs::Edge& rhs)
+    {
+      return (lhs.node_ids[0] < rhs.node_ids[0]) ||
+             (lhs.node_ids[0] == rhs.node_ids[0] && lhs.node_ids[1] < rhs.node_ids[1]);
+    });
+
+  return updates;
+}
+
+}  // namespace slam_karto

--- a/src/graph_update.cpp
+++ b/src/graph_update.cpp
@@ -19,10 +19,10 @@
 
 namespace slam_karto
 {
-void applyGraphChanges(locus_msgs::GraphStamped& graph, const locus_msgs::GraphUpdate& changes)
+void applyGraphUpdates(locus_msgs::GraphStamped& graph, const locus_msgs::GraphUpdate& updates)
 {
   // Add new nodes, update existing nodes
-  for (auto&& node : changes.node_changes)
+  for (auto&& node : updates.node_changes)
   {
     auto it = std::lower_bound(graph.graph.nodes.begin(), graph.graph.nodes.end(), node, nodeComparison);
     if (it == graph.graph.nodes.end() || it->id != node.id)
@@ -37,7 +37,7 @@ void applyGraphChanges(locus_msgs::GraphStamped& graph, const locus_msgs::GraphU
     }
   }
   // Add new edges. All edges in the GraphUpdate should be new. There is no such thing as a changed edge.
-  for (auto&& edge : changes.edge_changes)
+  for (auto&& edge : updates.edge_changes)
   {
     auto it = std::lower_bound(graph.graph.edges.begin(), graph.graph.edges.end(), edge, edgeComparison);
     if (it == graph.graph.edges.end() || it->node_ids != edge.node_ids)
@@ -46,6 +46,7 @@ void applyGraphChanges(locus_msgs::GraphStamped& graph, const locus_msgs::GraphU
       graph.graph.edges.insert(it, edge);
     }
   }
+  graph.header = updates.header;
 }
 
 locus_msgs::GraphUpdate computeGraphChanges(

--- a/src/slam_karto.cpp
+++ b/src/slam_karto.cpp
@@ -1248,16 +1248,17 @@ SlamKarto::updateMap()
       edge_msg.node_ids[1] = edge->GetTarget()->GetObject()->GetUniqueId();
       graph_msg.graph.edges.push_back(edge_msg);
     }
-    // Force the graph structure to be sorted. This will allow easier comparisons later.
-    std::sort(
-      graph_msg.graph.nodes.begin(),
-      graph_msg.graph.nodes.end(),
-      slam_karto::nodeComparison);
-    std::sort(
-      graph_msg.graph.edges.begin(),
-      graph_msg.graph.edges.end(),
-      slam_karto::edgeComparison);
   }
+
+  // Force the graph structure to be sorted. This will allow easier comparisons later.
+  std::sort(
+    graph_msg.graph.nodes.begin(),
+    graph_msg.graph.nodes.end(),
+    slam_karto::nodeComparison);
+  std::sort(
+    graph_msg.graph.edges.begin(),
+    graph_msg.graph.edges.end(),
+    slam_karto::edgeComparison);
 
   // Build a map from the laserscans
   karto::OccupancyGrid* occ_grid = karto::OccupancyGrid::CreateFromScans(scans, resolution_);
@@ -1349,7 +1350,7 @@ SlamKarto::updateMap()
     sstm_.publish(map_.map.info);
 
     // Publish the new graph
-    std::swap(graph_msg_, graph_msg);
+    graph_msg_ = std::move(graph_msg);
     graph_publisher_.publish(graph_msg_);
 
     // Publish just the major changes to the graph

--- a/src/slam_karto.cpp
+++ b/src/slam_karto.cpp
@@ -1356,7 +1356,7 @@ SlamKarto::updateMap()
     // The graph_update_reference_ accumulates all of the previously published changes
     // By comparing the accumulated updates to the full graph, we can find all changes, even if they happen slowly.
     auto graph_update = slam_karto::computeGraphChanges(graph_msg_, graph_update_reference_);
-    slam_karto::applyGraphChanges(graph_update_reference_, graph_update);
+    slam_karto::applyGraphUpdates(graph_update_reference_, graph_update);
     graph_updates_publisher_.publish(graph_update);
   }
 

--- a/src/slam_karto.cpp
+++ b/src/slam_karto.cpp
@@ -1252,15 +1252,11 @@ SlamKarto::updateMap()
     std::sort(
       graph_msg.graph.nodes.begin(),
       graph_msg.graph.nodes.end(),
-      [](const locus_msgs::Node& lhs, const locus_msgs::Node& rhs) { return lhs.id < rhs.id; });
+      slam_karto::nodeComparison);
     std::sort(
       graph_msg.graph.edges.begin(),
       graph_msg.graph.edges.end(),
-      [](const locus_msgs::Edge& lhs, const locus_msgs::Edge& rhs)
-      {
-        return (lhs.node_ids[0] < rhs.node_ids[0]) ||
-               (lhs.node_ids[0] == rhs.node_ids[0] && lhs.node_ids[1] < rhs.node_ids[1]);
-      });
+      slam_karto::edgeComparison);
   }
 
   // Build a map from the laserscans

--- a/test/test_graph_update.cpp
+++ b/test/test_graph_update.cpp
@@ -1,0 +1,319 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2023, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <locus_msgs/Edge.h>
+#include <locus_msgs/GraphStamped.h>
+#include <locus_msgs/GraphUpdate.h>
+#include <locus_msgs/Node.h>
+#include <slam_karto/graph_update.h>
+
+#include <gtest/gtest.h>
+
+
+TEST(ComputeGraphChanges, Empty)
+{
+  // Test that empty input messages do not cause problems. Output should also be empty.
+
+  auto previous = locus_msgs::GraphStamped();
+  auto current = locus_msgs::GraphStamped();
+
+  auto change_threshold = 0.05;
+  auto result = slam_karto::computeGraphChanges(current, previous, change_threshold);
+
+  EXPECT_TRUE(result.node_changes.empty());
+  EXPECT_TRUE(result.edge_changes.empty());
+}
+
+TEST(ComputeGraphChanges, EmptyCurrentGraph)
+{
+  // Test that a non-empty previous graph and an empty current graph returns an empty set. This is a short coming of
+  // the current Graph message format; there is no way to represent a deletion.
+
+  auto previous = locus_msgs::GraphStamped();
+  auto node1 = locus_msgs::Node();
+  node1.id = 1;
+  node1.position.x = 1.0;
+  node1.position.y = 2.0;
+  previous.graph.nodes.push_back(node1);
+
+  auto node2 = locus_msgs::Node();
+  node2.id = 2;
+  node2.position.x = 1.1;
+  node2.position.y = 2.2;
+  previous.graph.nodes.push_back(node2);
+
+  auto edge1 = locus_msgs::Edge();
+  edge1.node_ids[0] = 1;
+  edge1.node_ids[1] = 2;
+  previous.graph.edges.push_back(edge1);
+
+  auto current = locus_msgs::GraphStamped();
+
+  auto change_threshold = 0.05;
+  auto result = slam_karto::computeGraphChanges(current, previous, change_threshold);
+
+  EXPECT_TRUE(result.node_changes.empty());
+  EXPECT_TRUE(result.edge_changes.empty());
+}
+
+TEST(ComputeGraphChanges, EmptyPreviousGraph)
+{
+  // Test that an empty previous graph and a non-empty current graph returns all nodes and edges in the change set.
+
+  auto previous = locus_msgs::GraphStamped();
+
+  auto current = locus_msgs::GraphStamped();
+  auto node1 = locus_msgs::Node();
+  node1.id = 1;
+  node1.position.x = 1.0f;
+  node1.position.y = 2.0f;
+  current.graph.nodes.push_back(node1);
+
+  auto node2 = locus_msgs::Node();
+  node2.id = 2;
+  node2.position.x = 1.1f;
+  node2.position.y = 2.2f;
+  current.graph.nodes.push_back(node2);
+
+  auto edge1 = locus_msgs::Edge();
+  edge1.node_ids[0] = 1;
+  edge1.node_ids[1] = 2;
+  current.graph.edges.push_back(edge1);
+
+  auto change_threshold = 0.05;
+  auto result = slam_karto::computeGraphChanges(current, previous, change_threshold);
+
+  ASSERT_EQ(result.node_changes.size(), 2u);
+  EXPECT_EQ(result.node_changes[0].id, 1u);
+  EXPECT_FLOAT_EQ(result.node_changes[0].position.x, 1.0f);
+  EXPECT_FLOAT_EQ(result.node_changes[0].position.y, 2.0f);
+  EXPECT_EQ(result.node_changes[1].id, 2u);
+  EXPECT_FLOAT_EQ(result.node_changes[1].position.x, 1.1f);
+  EXPECT_FLOAT_EQ(result.node_changes[1].position.y, 2.2f);
+
+  ASSERT_EQ(result.edge_changes.size(), 1u);
+  EXPECT_EQ(result.edge_changes[0].node_ids[0], 1u);
+  EXPECT_EQ(result.edge_changes[0].node_ids[1], 2u);
+}
+
+TEST(ComputeGraphChanges, NewEntries)
+{
+  // Include some new entries along with the original entries in the current graph. The output should only contain
+  // the new entries.
+
+  auto previous = locus_msgs::GraphStamped();
+  auto node1 = locus_msgs::Node();
+  node1.id = 1;
+  node1.position.x = 1.0;
+  node1.position.y = 2.0;
+  previous.graph.nodes.push_back(node1);
+
+  auto node2 = locus_msgs::Node();
+  node2.id = 2;
+  node2.position.x = 1.1;
+  node2.position.y = 2.2;
+  previous.graph.nodes.push_back(node2);
+
+  auto edge1 = locus_msgs::Edge();
+  edge1.node_ids[0] = 1;
+  edge1.node_ids[1] = 2;
+  previous.graph.edges.push_back(edge1);
+
+  // Copy the previous graph, then add additional entries
+  auto current = previous;
+  auto node3 = locus_msgs::Node();
+  node3.id = 3;
+  node3.position.x = 1.5;
+  node3.position.y = 2.5;
+  current.graph.nodes.push_back(node3);
+
+  auto edge2 = locus_msgs::Edge();
+  edge2.node_ids[0] = 2;
+  edge2.node_ids[1] = 3;
+  current.graph.edges.push_back(edge2);
+
+  auto edge3 = locus_msgs::Edge();
+  edge3.node_ids[0] = 1;
+  edge3.node_ids[1] = 3;
+  current.graph.edges.push_back(edge3);
+
+  auto change_threshold = 0.05;
+  auto result = slam_karto::computeGraphChanges(current, previous, change_threshold);
+
+  ASSERT_EQ(result.node_changes.size(), 1u);
+  EXPECT_EQ(result.node_changes[0].id, 3u);
+  EXPECT_FLOAT_EQ(result.node_changes[0].position.x, 1.5f);
+  EXPECT_FLOAT_EQ(result.node_changes[0].position.y, 2.5f);
+
+  ASSERT_EQ(result.edge_changes.size(), 2u);
+  EXPECT_EQ(result.edge_changes[0].node_ids[0], 2u);
+  EXPECT_EQ(result.edge_changes[0].node_ids[1], 3u);
+  EXPECT_EQ(result.edge_changes[1].node_ids[0], 1u);
+  EXPECT_EQ(result.edge_changes[1].node_ids[1], 3u);
+}
+
+TEST(ComputeGraphChanges, MissingEntries)
+{
+  // Include some new entries in the current graph, but the current graph also has some missing entries relative to the
+  // previous graph. The output will only include the new entries as the current message structure does not support
+  // deleted entries.
+
+  auto previous = locus_msgs::GraphStamped();
+  auto node1 = locus_msgs::Node();
+  node1.id = 1;
+  node1.position.x = 1.0;
+  node1.position.y = 2.0;
+  previous.graph.nodes.push_back(node1);
+
+  auto node2 = locus_msgs::Node();
+  node2.id = 2;
+  node2.position.x = 1.1;
+  node2.position.y = 2.2;
+  previous.graph.nodes.push_back(node2);
+
+  auto node3 = locus_msgs::Node();
+  node3.id = 3;
+  node3.position.x = 1.5;
+  node3.position.y = 2.5;
+  previous.graph.nodes.push_back(node3);
+
+  auto edge1 = locus_msgs::Edge();
+  edge1.node_ids[0] = 1;
+  edge1.node_ids[1] = 2;
+  previous.graph.edges.push_back(edge1);
+
+  auto edge2 = locus_msgs::Edge();
+  edge2.node_ids[0] = 1;
+  edge2.node_ids[1] = 3;
+  previous.graph.edges.push_back(edge2);
+
+  auto edge3 = locus_msgs::Edge();
+  edge3.node_ids[0] = 2;
+  edge3.node_ids[1] = 3;
+  previous.graph.edges.push_back(edge3);
+
+  // Include only some of the entries from the previous graph, then add additional entries
+  auto current = locus_msgs::GraphStamped();
+  current.graph.nodes.push_back(node1);
+  current.graph.nodes.push_back(node3);
+
+  auto node4 = locus_msgs::Node();
+  node4.id = 4;
+  node4.position.x = 1.6;
+  node4.position.y = 2.6;
+  current.graph.nodes.push_back(node4);
+
+  auto edge4 = locus_msgs::Edge();
+  edge4.node_ids[0] = 1;
+  edge4.node_ids[1] = 4;
+  current.graph.edges.push_back(edge4);
+
+  // Edges must be sorted
+  current.graph.edges.push_back(edge3);
+
+  auto edge5 = locus_msgs::Edge();
+  edge5.node_ids[0] = 3;
+  edge5.node_ids[1] = 4;
+  current.graph.edges.push_back(edge5);
+
+  auto change_threshold = 0.05;
+  auto result = slam_karto::computeGraphChanges(current, previous, change_threshold);
+
+  ASSERT_EQ(result.node_changes.size(), 1u);
+  EXPECT_EQ(result.node_changes[0].id, 4u);
+  EXPECT_FLOAT_EQ(result.node_changes[0].position.x, 1.6f);
+  EXPECT_FLOAT_EQ(result.node_changes[0].position.y, 2.6f);
+
+  ASSERT_EQ(result.edge_changes.size(), 2u);
+  EXPECT_EQ(result.edge_changes[0].node_ids[0], 1u);
+  EXPECT_EQ(result.edge_changes[0].node_ids[1], 4u);
+  EXPECT_EQ(result.edge_changes[1].node_ids[0], 3u);
+  EXPECT_EQ(result.edge_changes[1].node_ids[1], 4u);
+}
+
+TEST(ComputeGraphChanges, ChangedNodes)
+{
+  // Move the position of some nodes between the previous and current graph. If a node moves enough, it should be
+  // reported in the output.
+  auto previous = locus_msgs::GraphStamped();
+  auto node1 = locus_msgs::Node();
+  node1.id = 1;
+  node1.position.x = 1.0;
+  node1.position.y = 2.0;
+  previous.graph.nodes.push_back(node1);
+
+  auto node2 = locus_msgs::Node();
+  node2.id = 2;
+  node2.position.x = 1.1;
+  node2.position.y = 2.2;
+  previous.graph.nodes.push_back(node2);
+
+  auto node3 = locus_msgs::Node();
+  node3.id = 3;
+  node3.position.x = 1.5;
+  node3.position.y = 2.5;
+  previous.graph.nodes.push_back(node3);
+
+  auto current = locus_msgs::GraphStamped();
+  // Node 1 moved enough for the default threshold
+  node1.position.y = 2.06f;
+  current.graph.nodes.push_back(node1);
+
+  // Node 2 did not move enough
+  node2.position.x = 1.14f;
+  current.graph.nodes.push_back(node2);
+
+  // Node 3 moved enough when considering both X and Y
+  node3.position.x = 1.44f;
+  node3.position.y = 2.54f;
+  current.graph.nodes.push_back(node3);
+
+  auto change_threshold = 0.05;
+  auto result = slam_karto::computeGraphChanges(current, previous, change_threshold);
+
+  ASSERT_EQ(result.node_changes.size(), 2u);
+  EXPECT_EQ(result.node_changes[0].id, 1u);
+  EXPECT_FLOAT_EQ(result.node_changes[0].position.x, 1.00f);
+  EXPECT_FLOAT_EQ(result.node_changes[0].position.y, 2.06f);
+  EXPECT_EQ(result.node_changes[1].id, 3u);
+  EXPECT_FLOAT_EQ(result.node_changes[1].position.x, 1.44f);
+  EXPECT_FLOAT_EQ(result.node_changes[1].position.y, 2.54f);
+
+  ASSERT_EQ(result.edge_changes.size(), 0u);
+}
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
The Magellen web UI for the mapping software would like to display the SLAM graph to the users. The original prototype abused the Rviz visualization message to extract a graph structure for Magellan. However, there were a few issues with this approach:
* First, the obvious: An rviz visualization message should not be used as the source of truth for anything
* Second, the graph structure was encoded as a GeoJSON string, which is not an efficient encoding strategy for large amounts of data.
* Third, the entire graph structure is included for every update, despite the fact that very little has changed on any given update.

This PR:
* Makes publishing the graph structure part of the SLAM node itself, in the same way that the map is published. Rather than parsing out a visualization message in a separate node.
* Publishes the SLAM graph structure using a more formal message structure (locusrobotics/locus_msgs#107). This makes it easier to reason about the graph, as well as reduces the message size.
* Further message size reduction is provided by computing the changes to the graph with each update, and only the graph changes are published.
* A service call is provided to get the entire graph on demand.