### PR TITLE
Adding a check for empty scans

### DIFF
--- a/src/slam_karto.cpp
+++ b/src/slam_karto.cpp
@@ -537,6 +537,11 @@ SlamKarto::laserCallback(const sensor_msgs::LaserScan::ConstPtr& scan)
   if ((laser_count_ % throttle_scans_) != 0)
     return;
 
+  if (scan->ranges.empty())
+  {
+    ROS_WARN("Empty scan detected, returning");
+    return;
+  }
   static ros::Time last_map_update(0,0);
 
   // Check whether we know about this laser yet


### PR DESCRIPTION
This is more of an investigative change for https://locusrobotics.atlassian.net/browse/RST-13109, because I cannot replicate this failure locally. Let's see if the cloud gives us anything